### PR TITLE
Update timelinejs.html

### DIFF
--- a/layouts/shortcodes/timelinejs.html
+++ b/layouts/shortcodes/timelinejs.html
@@ -25,19 +25,9 @@
 
 <!-- Inject div element -->
 <div class="mod-timeline">
-{{ with $blockId }}
-  <div id={{ . | safeHTML }}></div>
-{{ end }}
+  <div id={{ $blockId | safeHTML }}></div>
 </div>
 <!-- This instantiates the timelinejs element. -->
 <script type="text/javascript">
-  document.addEventListener("DOMContentLoaded", function () {
-    window.timeline = new TL.Timeline(
-    {{ with $blockId }}
-      {{ . | safeJSStr }},
-    {{ end }}
-    {{ with $jsonFile }}
-      {{ . | safeJSStr }})
-    {{ end }}
-  });
+  timeline = new TL.Timeline({{ $blockId | safeJSStr }},{{ $jsonFile | safeJSStr }});
 </script>


### PR DESCRIPTION
Removed the "{{ with $VARIABLE }}" articles from the file, and instead went with direct variable injection. 

This was due to discovering a ";", a semicolon, was clipped from the last line of the timeline initiation script, this caused the JavaScript to fail when loading. New formatting should produce a more consistent result.