### PR TITLE
Reverting target from core to main

### DIFF
--- a/exampleSite/layouts/partials/footer/scripts.html
+++ b/exampleSite/layouts/partials/footer/scripts.html
@@ -1,16 +1,16 @@
-{{- $filename := .filename | default "js/core.bundle.js" -}}
+{{- $filename := .filename | default "js/main.bundle.js" -}}
 {{- $match := .match | default "js/**.js" -}}
 {{- $page := .page -}}
 
 {{- warnf "Processing js pattern: %s" $match -}}
 {{ $files := sort (resources.Match $match) "Key" "asc" }}
 {{- range $index, $file := $files -}}
-    {{- warnf " - Processing file: %s" $file.Key }}
+{{- warnf " - Processing file: %s" $file.Key }}
 {{- end -}}
 
 {{ if gt (len $files) 0 }}
-    {{ $bundle := $files | resources.Concat $filename -}}
-    {{ $js := $bundle | resources.ExecuteAsTemplate $filename $page -}}
+{{ $bundle := $files | resources.Concat $filename -}}
+{{ $js := $bundle | resources.ExecuteAsTemplate $filename $page -}}
 
-    <script src="{{ $js.Permalink }}"></script>
+<script src="{{ $js.Permalink }}"></script>
 {{ end -}}

--- a/package.hugo.json
+++ b/package.hugo.json
@@ -1,6 +1,6 @@
 {
   "name": "@anoduck/mod-timelinejs",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "description": "A Hinode Module to allow users of hinode to use the timelinejs library for more dynamic timelines.",
   "keywords": [
     "hugo",

--- a/package.json
+++ b/package.json
@@ -112,5 +112,5 @@
     "test": "npm run -s build",
     "upgrade": "npx npm-check-updates -u && npm run -s mod:update"
   },
-  "version": "0.0.42"
+  "version": "0.0.43"
 }


### PR DESCRIPTION
The target of transpilation in `scripts.html` was reverted to the original `main.bundle.js` from `core.bundle.js` as it should have been. This chore was completely forgotten about, and explains the recent lack of functionality.