### PR TITLE
refactor: refactoring of autoload.js

### DIFF
--- a/assets/js/modules/timelinejs/autoload.js
+++ b/assets/js/modules/timelinejs/autoload.js
@@ -1,7 +1,16 @@
-document.addEventListener("DOMContentLoaded", function() {
-    const tlObj = document.querySelector('.mod-timeline');
-    let blockId = tlObj.id;
-    let jsonFile = tlObj.dataset.name;
+const tlCon = document.querySelector('#timeline-container');
+const tlObj = tlCon.querySelector('div:first-child');
+let blockId = tlObj.id;
+let jsonFile = tlObj.dataset.name;
+let scripts = document.getElementsByTagName('script');
+let jsPath = scripts[scripts.length-1].src;
 
+let Options ={
+    height: 650,
+    script_path: jsPath,
+    debug: false
+};
+
+window.onload = function () {
     window.timeline = new TL.Timeline(blockId, jsonFile);
-});
+};

--- a/assets/scss/timelinejs.scss
+++ b/assets/scss/timelinejs.scss
@@ -2,17 +2,17 @@
 @use 'modules/timelinejs/font.default.scss';
 
 tl-timenav {
-  height: 150px;
+  min-height: 150px;
   pointer-events: none;
 }
 
 tl-storyslider {
-  height: 400px;
+  min-height: 400px;
   pointer-events: none;
 }
 
 @mixin tl-container($container-width, $max-width: null) {
-  height: 675px;
+  min-height: 675px;
   pointer-events: none;
   // First we will do width
   @if not $container-width or not $max-width {

--- a/layouts/shortcodes/timelinejs.html
+++ b/layouts/shortcodes/timelinejs.html
@@ -21,10 +21,10 @@
 
 <!-- Define Variables -->
 {{- $blockId := .Get "blockId" | default "timeline-element" -}}
-{{- $jsonFile := .Get "jsonFile" | default "timelinejs.json" -}}
+{{- $jsonFile := .Get "jsonFile" | default "/timelinejs.json" -}}
 
 <!-- Inject div element -->
-<div class="tl-container">
-    <div class="mod-timeline" id={{ $blockId | safeHTML }} data-name={{ $jsonFile | safeHTML }}></div>
+<div class="tl-container" id="timeline-container">
+    <div id={{ $blockId | safeHTML }} data-name={{ $jsonFile | safeHTML }}></div>
 </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anoduck/mod-timelinejs",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anoduck/mod-timelinejs",
-      "version": "0.0.54",
+      "version": "0.0.55",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anoduck/mod-timelinejs",
-  "version": "0.0.55",
+  "version": "0.0.56",
   "description": "A Hinode Module to allow users of hinode to use the timelinejs library for more dynamic timelines.",
   "keywords": [
     "hugo",


### PR DESCRIPTION
Autoload refactored due to timeline.js overwriting designated class of element. Also added back in options to JavaScript, significantly script_path.