### PR TITLE
fix(timelinejs.scss): use libsass

### DIFF
--- a/exampleSite/layouts/partials/head/stylesheet.html
+++ b/exampleSite/layouts/partials/head/stylesheet.html
@@ -8,7 +8,7 @@
     {{- $files = $files | append $file -}}
 {{- end -}}
 
-{{- $options := (dict "transpiler" "dartsass" "targetPath" $target) -}}
+{{- $options := (dict "transpiler" "libsass" "targetPath" $target) -}}
 {{- $options = merge $options (dict "outputStyle" "expanded") -}}
 
 {{- $css := resources.GetMatch $source | resources.ExecuteAsTemplate "style.app.scss" . | toCSS $options -}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anoduck/mod-timelinejs",
-  "version": "0.0.61",
+  "version": "0.0.62",
   "description": "A Hinode Module to allow users of hinode to use the timelinejs library for more dynamic timelines.",
   "keywords": [
     "hugo",


### PR DESCRIPTION
Dartsass is believed to be the cause of a transpilation error specific to this module, so to mitigate, libsass is now preferred.