### PR TITLE
refactor: relabeled data identifier from jsonFile to tlData

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You can use a JSON file or a Google spreadsheet to provide the data, because the
 
 Data is stored in the `static` data in the form of a json file. More information about the format of the json file can be found on [KnightLab's webiste](https://timeline.knightlab.com/docs/json-format.html). The shortcode only takes two arguments, which are described below.
 
-To you a Google spreadsheet simply place the full url of the spreadsheet share link where you would place the json file, I.E. the `jsonFile` property. You can use [KnightLab's Template](https://docs.google.com/spreadsheets/d/1pHBvXN7nmGkiG8uQSUB82eNlnL8xHu6kydzH_-eguHQ/copy) to get started.
+To you a Google spreadsheet simply place the full url of the spreadsheet share link where you would place the json file, I.E. the `tlData` property. You can use [KnightLab's Template](https://docs.google.com/spreadsheets/d/1pHBvXN7nmGkiG8uQSUB82eNlnL8xHu6kydzH_-eguHQ/copy) to get started.
 
 ### BlockId
 
@@ -59,13 +59,13 @@ In order to tell the script where to generate the timeline, an "id" is provided.
 
 | Setting                   | Default            | Description                                         |
 |---------------------------|--------------------|-----------------------------------------------------|
-| jsonFile                  | "timelinejs.json"  | The JSON file or Google Sheet containing event data |
+| tlData                  | "timelinejs.json"  | The JSON file or Google Sheet containing event data |
 | blockId                   | "timeline-content" | The "id" attribute assigned to the timeline.        |
 
 The shortcode can be used with the following labeled arguments.
 
 ```html
-{{< timelinejs blockId="timeline-element" jsonFile="/timelinejs.json" >}}
+{{< timelinejs blockId="timeline-element" tlData="/timelinejs.json" >}}
 <!-- or -->
 {{< timelinejs "timeline-element" "/timelinejs.json" >}}
 ```

--- a/contrib/js/autoload.js
+++ b/contrib/js/autoload.js
@@ -1,7 +1,7 @@
 const tlCon = document.querySelector('#timeline-container');
 const tlObj = tlCon.querySelector('div:first-child');
 let blockId = tlObj.id;
-let jsonFile = tlObj.dataset.name;
+let tlData = tlObj.dataset.name;
 let scripts = document.getElementsByTagName('script');
 let jsPath = scripts[scripts.length-1].src;
 
@@ -11,5 +11,5 @@ let Options ={
 };
 
 window.onload = function () {
-    window.timeline = new TL.Timeline(blockId, jsonFile);
+    window.timeline = new TL.Timeline(blockId, tlData);
 };

--- a/dist/js/autoload.js
+++ b/dist/js/autoload.js
@@ -1,7 +1,7 @@
 const tlCon = document.querySelector('#timeline-container');
 const tlObj = tlCon.querySelector('div:first-child');
 let blockId = tlObj.id;
-let jsonFile = tlObj.dataset.name;
+let tlData = tlObj.dataset.name;
 let scripts = document.getElementsByTagName('script');
 let jsPath = scripts[scripts.length-1].src;
 
@@ -11,5 +11,5 @@ let Options ={
 };
 
 window.onload = function () {
-    window.timeline = new TL.Timeline(blockId, jsonFile);
+    window.timeline = new TL.Timeline(blockId, tlData);
 };

--- a/exampleSite/content/_index.md
+++ b/exampleSite/content/_index.md
@@ -6,6 +6,6 @@ date: 2023-07-10
 
 __There should be a fancy Timeline element below.__
 
-{{< timelinejs blockId="timeline-element" jsonFile="timelinejs.json" >}}
+{{< timelinejs blockId="timeline-element" tlData="timelinejs.json" >}}
 
 If there is not, then check the browser console to see if it loaded, then inspect the element to see if the element has the proper dimensions.

--- a/layouts/shortcodes/timelinejs.html
+++ b/layouts/shortcodes/timelinejs.html
@@ -17,14 +17,14 @@
 
 <!-- Initialize arguments -->
 {{- $blockId := "" -}}
-{{- $jsonFile := "" -}}
+{{- $tlData := "" -}}
 
 <!-- Define Variables -->
 {{- $blockId := .Get "blockId" | default "timeline-element" -}}
-{{- $jsonFile := .Get "jsonFile" | default "data/timelinejs.json" -}}
+{{- $tlData := .Get "tlData" | default "data/timelinejs.json" -}}
 
 <!-- Inject div element -->
 <div class="tl-container" id="timeline-container">
-    <div id={{ $blockId | safeHTML }} data-name={{ $jsonFile | safeHTML }}></div>
+    <div id={{ $blockId | safeHTML }} data-name={{ $tlData | safeHTML }}></div>
 </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anoduck/mod-timelinejs",
-  "version": "0.0.68",
+  "version": "0.0.69",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anoduck/mod-timelinejs",
-      "version": "0.0.68",
+      "version": "0.0.69",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anoduck/mod-timelinejs",
-  "version": "0.0.68",
+  "version": "0.0.69",
   "description": "A Hinode Module to allow users of hinode to use the timelinejs library for more dynamic timelines.",
   "keywords": [
     "hugo",


### PR DESCRIPTION
Changed data identifier to a more true descriptor of the data representation, allowing jsonfile and google sheet urls as well.

BREAKING CHANGE: Use of jsonFile will no longer be valid with shortcodes, please use "tlData" instead and use with json files as well as google sheet urls.